### PR TITLE
First cut: consecutive transactions

### DIFF
--- a/bigchaindb_benchmark/bdb.py
+++ b/bigchaindb_benchmark/bdb.py
@@ -1,34 +1,107 @@
 import time
+import uuid
 
 
 from bigchaindb_driver import BigchainDB
 from bigchaindb_driver.crypto import generate_keypair
+from bigchaindb_driver.exceptions import NotFoundError
 
 
-def generate(size=None):
+def generate_create(signer, size=None):
     driver = BigchainDB()
-    alice = generate_keypair()
     asset = None
 
     if size:
         asset = {'data': {'_': 'x' * size}}
 
+    metadata = {'nounce': str(uuid.uuid4())}
+
     prepared_creation_tx = driver.transactions.prepare(
         operation='CREATE',
-        signers=alice.public_key,
+        signers=signer.public_key,
         asset=asset,
-        metadata=None)
+        metadata=metadata)
 
     fulfilled_creation_tx = driver.transactions.fulfill(
         prepared_creation_tx,
-        private_keys=alice.private_key)
+        private_keys=signer.private_key)
 
     return fulfilled_creation_tx
 
 
-def infinite_generate(repeat=1, size=None):
+def generate_transfer(prev, signer, size=None):
+    driver = BigchainDB()
+    asset = None
+
+    if prev['operation'] == 'CREATE':
+        asset = {
+            'id': prev['id']
+        }
+    elif prev['operation'] == 'TRANSFER':
+        asset = {
+            'id': prev['asset']['id']
+        }
+
+    output_index = 0
+    output = prev['outputs'][output_index]
+
+    transfer_input = {
+        'fulfillment': output['condition']['details'],
+        'fulfills': {
+            'output_index': output_index,
+            'transaction_id': prev['id']
+        },
+        'owners_before': output['public_keys']
+    }
+
+    prepared_transfer_tx = driver.transactions.prepare(
+        operation='TRANSFER',
+        asset=asset,
+        inputs=transfer_input,
+        recipients=signer.public_key,
+    )
+
+    fulfilled_transfer_tx = driver.transactions.fulfill(
+        prepared_transfer_tx,
+        private_keys=signer.private_key,
+    )
+
+    return fulfilled_transfer_tx
+
+
+def check_status(transaction_id):
+    driver = BigchainDB()
+
+    trys = 0
+    status = None
+    while trys < 60:
+        try:
+            status = driver.transactions.status(transaction_id).get('status') == 'valid'
+            if status:
+                break
+        except NotFoundError:
+            time.sleep(1)
+            check_status(transaction_id)
+    return status
+
+
+def infinite_generate(repeat=1, size=None, consecutive=False):
+    signer = generate_keypair()
+    tx = None
+
     while True:
-        tx = generate(size)
+        if consecutive:
+            if tx is None:
+                tx = generate_create(signer, size)
+            else:
+
+                status = check_status(tx['id'])
+                if status:
+                    tx = generate_transfer(tx, signer, size)
+
+        else:
+            tx = generate_create(signer, size)
+
         for _ in range(repeat):
             yield tx
 

--- a/bigchaindb_benchmark/commands.py
+++ b/bigchaindb_benchmark/commands.py
@@ -20,7 +20,8 @@ def run_send(args):
                 send,
                 zip(args.peer * args.requests,
                     bdb.infinite_generate(args.broadcast,
-                                          args.size)))
+                                          args.size,
+                                          args.consecutive)))
         for peer, txid, delta in results:
             logger.info('Send %s to %s [%.3fms]', txid, peer, delta * 1e3)
 
@@ -65,6 +66,11 @@ def create_parser():
                              help='Number of transactions to send to a peer.',
                              type=int,
                              default=1)
+
+    send_parser.add_argument('--consecutive', '-c',
+                             help='Send consecutive TRANSFER transactions.',
+                             type=bool,
+                             default=False)
 
     send_parser.add_argument('--broadcast', '-b',
                              help='Broadcast the same transaction N peers. '


### PR DESCRIPTION
I needed this functionality myself quickly.

That's why I hacked it together on this tool rather than creating my own.

Things that I'd like to improve but would like to have input from others:

- argument name: `--consecutive -c` does that make sense?
- dat generator function, I'm doing horrible stuff with it. Can this be done more elegantly?
- more...