### PR TITLE
Problem: continue posting transactions to system at high load causes the system to halt with incomplete test results

### DIFF
--- a/bigchaindb_benchmark/bdb.py
+++ b/bigchaindb_benchmark/bdb.py
@@ -1,12 +1,15 @@
+import requests
 from uuid import uuid4
 from itertools import count
+from time import sleep
 
 from .utils import ts
 
 from bigchaindb_driver import BigchainDB
 from bigchaindb_driver.exceptions import TransportError
 from bigchaindb_driver.crypto import generate_keypair
-
+from cachetools.func import ttl_cache
+from urllib.parse import urlparse
 
 def _generate(keypair=None, size=None):
     driver = BigchainDB()
@@ -40,8 +43,30 @@ def generate(keypair=None, size=None, amount=None):
             return
         yield _generate(keypair, size)
 
+@ttl_cache(ttl=60)
+def get_unconfirmed_tx(tm_http_api):
+    num_unconfirmed_txs_api = '/num_unconfirmed_txs'
+    tm_http_api = tm_http_api.strip('/')
+    url = tm_http_api + num_unconfirmed_txs_api
+    try:
+        resp = requests.get(url)
+        if resp.status_code == requests.codes.ok:
+            return int(resp.json()['result']['n_txs'])
+    except:
+        raise
 
 def send(args, peer, tx):
+    # Stop sending transactions if unconfirmed
+    # transaction in mempool are above the set
+    # threshold
+    TM_HTTP_ENDPOINT = 'http://{}:26657'.format(urlparse(peer).hostname)
+    unconfirmed_tx_th = args.unconfirmed_tx_th
+    unconfirmed_txs = get_unconfirmed_tx(TM_HTTP_ENDPOINT)
+    backoff_time = 0.5
+    while unconfirmed_txs > unconfirmed_tx_th:
+        sleep(backoff_time)
+        unconfirmed_txs = get_unconfirmed_tx(TM_HTTP_ENDPOINT)
+
     driver = BigchainDB(peer, headers=args.auth)
 
     ts_send = ts()

--- a/bigchaindb_benchmark/commands.py
+++ b/bigchaindb_benchmark/commands.py
@@ -134,6 +134,11 @@ def create_parser():
                              type=int,
                              default=1)
 
+    send_parser.add_argument('--unconfirmed_tx_th', '-th',
+                             help='Threshold for number of unconfirmed transactions in tendermint mempool',
+                             type=int,
+                             default=5000)
+
     return parser
 
 def configure(args):

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ setup(
         'coloredlogs~=7.3.0',
         'websocket-client',
         'logstats~=0.3.0',
+        'requests~=2.19.1',
+        'cachetools~=2.1.0',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Solution: Add throttle based on unconfirmed transactions in mempool to benchmark client and back off when system halts until system recovers to normal operation